### PR TITLE
Don't start the server during the init step

### DIFF
--- a/lib/virginia/plugin.rb
+++ b/lib/virginia/plugin.rb
@@ -1,7 +1,7 @@
 module Virginia
   class Plugin < Adhearsion::Plugin
 
-    init :virginia do
+    run :virginia do
       logger.info "Virginia has been loaded"
       Service.start
     end


### PR DESCRIPTION
Applications initialize plugins in their test suites, so that things like i18n locales are loaded. These test suites may be run on servers where the Virginia port is already bound, such as on a production system. Thus, we must not actually start up the server.
