### PR TITLE
Initial document cache implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 0.4.0
+  * Add document cache
+
 # Version 0.3.0
   * Switch to Rackup-style app management
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ run Sinatra::Application
 
 Start Adhearsion.  You should be able to visit `http://localhost:8080/` in your browser and see "Hello world!"
 
+## Using the built-in document cache
+
+Assuming you are using Sinatra like in the above examples, put this in your `lib/sinatra_app.rb`:
+
+```Ruby
+require 'sinatra'
+require 'virginia/document_cache'
+
+get '/documents/:id' do
+  begin
+    grammar = Virginia::DocumentCache.fetch params[:id]
+  rescue Virginia::DocumentCache::NotFound
+    raise Sinatra::NotFound
+  end
+
+  grammar.to_s
+end
+```
+
+Then, to store a document in the cache, do this in your CallController:
+
+```Ruby
+cache_id = Virginia::DocumentCache.store 'Hello World!'
+virginia_config = Adhearsion.config.virginia
+logger.info "Document has been cached to http://#{virginia_config.host}:#{virginia_config.port}/documents/#{cache_id}"
+```
+
+You should be able to retrieve the document at the logged URL.
+
+
 ### Contributors
 
 Original author: [Luca Pradovera](https://github.com/polysics)

--- a/lib/virginia/document_cache.rb
+++ b/lib/virginia/document_cache.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+require 'singleton'
+
+module Virginia
+  class DocumentCache
+    include Singleton
+
+    NotFound = Class.new StandardError
+
+    attr_reader :mutex
+
+    class << self
+      def method_missing(m, *args, &block)
+        instance.mutex.synchronize do
+          instance.send m, *args, &block
+        end
+      end
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @documents = {}
+
+      supervisor = Housekeeping.supervise_as :document_cache_housekeeping
+      Adhearsion::Events.register_callback :shutdown do
+        supervisor.terminate
+      end
+    end
+
+    # Registers a new document with the cache
+    # @param [Object] document The document to be stored in the cache
+    # @param [Fixnum, Nil] lifetime The amount of time in seconds the document should be kept. If nil, document will be kept indefinitely
+    # @return [String] ID of the stored document
+    def store(document, lifetime = 10)
+      id = generate_id
+      @documents[id] = {
+        document: document,
+        expires: lifetime ? Time.now + lifetime : nil
+      }
+      id
+    end
+
+    # Deletes a document from the cache
+    # @param [Object] id ID of the document to be removed from the cache
+    # @return [Object, Nil] document Returns the document if found in the cache, nil otherwise
+    def delete(id)
+      data = @documents.delete id
+      data[:document]
+    end
+
+    # Retrieves a document from the cache
+    # @param [String] id ID of the document to be retrieved from the cache
+    # @return [Object] document Returns the document if found in the cache
+    # @raises [NotFound] If the document is not found in the cache
+    def fetch(id)
+      raise NotFound unless @documents.has_key? id
+      @documents[id][:document]
+    end
+
+    def reap_expired!
+      @documents.each_pair do |id, data|
+        @documents.delete(id) if data[:expires] < Time.now
+      end
+    end
+
+    class Housekeeping
+      include Celluloid
+
+      def initialize
+        every(1.minute) do
+          logger.debug "Reaping expired cached document"
+          DocumentCache.reap_expired!
+        end
+      end
+    end
+
+  private
+
+    def generate_id
+      SecureRandom.hex(16)
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to implement #10

- [x] In-memory document cache
- [x] Cache lifetimes and garbage collection
- [ ] Disk-backed storage for documents with infinite lifetime
- [ ] Helper method for constructing DocumentCache URIs
- [ ] Add optional Content-Type to documents so they can be served via HTTP