### PR TITLE
Feature: document server metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Add document metadata to the document cache. You must now specify the content type (or use the default of text/plain) when caching a document. This way Virginia knows how to serve it when it is requested.
   * Wrap cached documents and store them as Virginia::DocumentCache::Document
   * When retrieving a document from the cache, return the wrapped document
+  * DocumentCache#fetch no longer accepts a `lifetime` argument. Instead, return an array of arguments suitable for passing to `#store` from the block, or return a complete DocumentCache::Document
   * Switch DocumentCache to an Actor for better performance
   * Load & start DocumentCache's actor by default
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# develop
+  * BREAKING CHANGES! Read below:
+  * Support for storing document content-types with the document
+  * Add document metadata to the document cache. You must now specify the content type (or use the default of text/plain) when caching a document. This way Virginia knows how to serve it when it is requested.
+  * Wrap cached documents and store them as Virginia::DocumentCache::Document
+  * When retrieving a document from the cache, return the wrapped document
+  * Switch DocumentCache to an Actor for better performance
+  * Load & start DocumentCache's actor by default
+
 # Version 0.4.0
   * Add document cache
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec', :version => 2, :cli => '--format documentation' do
+guard 'rspec', cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec/" }

--- a/README.md
+++ b/README.md
@@ -57,16 +57,15 @@ Assuming you are using Sinatra like in the above examples, put this in your `lib
 
 ```Ruby
 require 'sinatra'
-require 'virginia/document_cache'
 
 get '/documents/:id' do
   begin
-    grammar = Virginia::DocumentCache.fetch params[:id]
+    document = Virginia::DocumentCache.fetch params[:id]
+    headers['Content-Type'] = document.content_type
+    document.body
   rescue Virginia::DocumentCache::NotFound
     raise Sinatra::NotFound
   end
-
-  grammar.to_s
 end
 ```
 

--- a/lib/virginia.rb
+++ b/lib/virginia.rb
@@ -1,11 +1,10 @@
 require "adhearsion"
-require "active_support/dependencies/autoload"
-require "virginia/version"
-require "virginia/plugin"
+%w(
+  version
+  plugin
+  service
+  document_cache
+).each { |file| require "virginia/#{file}" }
 
 module Virginia
-  extend ActiveSupport::Autoload
-  autoload :Plugin
-  autoload :Service
-  autoload :LoggingHandler
 end

--- a/lib/virginia/document_cache.rb
+++ b/lib/virginia/document_cache.rb
@@ -1,9 +1,10 @@
 # encoding: utf-8
 require 'singleton'
+require 'virginia/document_cache/document'
 
 module Virginia
   class DocumentCache
-    include Singleton
+    include Celluloid
 
     NotFound = Class.new StandardError
 
@@ -11,19 +12,16 @@ module Virginia
 
     class << self
       def method_missing(m, *args, &block)
-        instance.mutex.synchronize do
-          instance.send m, *args, &block
-        end
+        Celluloid::Actor[:virginia_document_cache].send m, *args, &block
       end
     end
 
     def initialize
-      @mutex = Mutex.new
       @documents = {}
 
-      supervisor = Housekeeping.supervise_as :document_cache_housekeeping
-      Adhearsion::Events.register_callback :shutdown do
-        supervisor.terminate
+      every(60) do
+        logger.debug "Reaping expired cached document"
+        reap_expired!
       end
     end
 
@@ -31,56 +29,49 @@ module Virginia
     # @param [Object] document The document to be stored in the cache
     # @param [Fixnum, Nil] lifetime The amount of time in seconds the document should be kept. If nil, document will be kept indefinitely.
     # @param [String, Nil] id The ID to use to store the document. If nil, one will be generated.
-    # @return [String] ID of the stored document
-    def store(document, lifetime = 10, id = nil)
+    # @return [String] Cache ID of the stored document
+    def store(document, content_type = 'text/plain', lifetime = 10, id = nil)
       id ||= generate_id
-      @documents[id] = {
-        document: document,
-        expires: lifetime ? Time.now + lifetime : nil
-      }
-      id
+      doc = Virginia::DocumentCache::Document.new id, document, content_type, lifetime
+      store_document doc
+    end
+
+    # Registers a new Virginia::DocumentCache::Document with the cache
+    # @param [Virginia::DocumentCache::Document] document The document to be stored in the cache
+    # @return [String] Cache ID of the stored document
+    def store_document(document)
+      @documents[document.id] =  document
+      document.id
     end
 
     # Deletes a document from the cache
     # @param [Object] id ID of the document to be removed from the cache
     # @return [Object, Nil] document Returns the document if found in the cache, nil otherwise
     def delete(id)
-      data = @documents.delete id
-      data[:document]
+      @documents.delete id
     end
 
     # Retrieves a document from the cache
     # @param [String] id ID of the document to be retrieved from the cache
     # @param [Fixnum, Nil] lifetime The amount of time in seconds the document should be kept. If nil, document will be kept indefinitely.
     # @yield If given, will be used to generate the document, store it, and then return.
-    # @return [Object] document Returns the document if found in the cache
-    # @raises [NotFound] If the document is not found in the cache
+    # @return [Virginia::DocumentCache::Document] Returns the document if found in the cache
+    # @raises [Virginia::DocumentCache::NotFound] If the document is not found in the cache
     def fetch(id, lifetime = 10)
       unless @documents.has_key? id
         if block_given?
           store yield, lifetime, id
         else
-          raise NotFound
+          abort NotFound.new
         end
       end
-      
-      @documents[id][:document]
+
+      @documents[id]
     end
 
     def reap_expired!
-      @documents.each_pair do |id, data|
-        @documents.delete(id) if data[:expires] < Time.now
-      end
-    end
-
-    class Housekeeping
-      include Celluloid
-
-      def initialize
-        every(1.minute) do
-          logger.debug "Reaping expired cached document"
-          DocumentCache.reap_expired!
-        end
+      @documents.each_pair do |id, doc|
+        @documents.delete(id) if doc[:expires_at] < Time.now
       end
     end
 

--- a/lib/virginia/document_cache/document.rb
+++ b/lib/virginia/document_cache/document.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+module Virginia
+  class DocumentCache
+    class Document < Struct.new(:id, :body, :content_type, :lifetime, :created_at, :expires_at)
+      def initialize(id, body, content_type = 'text/plain', lifetime = nil)
+        self.id, self.body, self.content_type, self.lifetime = id, body, content_type, lifetime
+        self.created_at = Time.now
+        if self.lifetime
+          self.expires_at = self.created_at + self.lifetime
+        end
+      end
+    end
+  end
+end

--- a/lib/virginia/plugin.rb
+++ b/lib/virginia/plugin.rb
@@ -6,6 +6,12 @@ module Virginia
     run :virginia do
       logger.info "Virginia has been loaded"
       Service.start
+
+      # Document Cache
+      supervisor = Virginia::DocumentCache.supervise_as(:virginia_document_cache)
+      Adhearsion::Events.register_callback :shutdown do
+        supervisor.terminate
+      end
     end
 
     config :virginia do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'timecop'
 ENV['AHN_ENV'] = 'test'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
   config.tty = true
 
   config.filter_run :focus => true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'adhearsion'
 require 'virginia'
+require 'timecop'
 
 ENV['AHN_ENV'] = 'test'
 

--- a/spec/virginia/document_cache/document_spec.rb
+++ b/spec/virginia/document_cache/document_spec.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Virginia::DocumentCache::Document do
+  let(:subject) { Virginia::DocumentCache::Document }
+
+  before :each do
+    Timecop.freeze
+    @document = subject.new 'fake_id', 'fake_content'
+  end
+
+  after :each do
+    Timecop.return
+  end
+
+  it 'should accurately represent my content' do
+    expect(@document.body).to eq 'fake_content'
+  end
+
+  it 'should automatically set the created_at time' do
+    expect(@document.created_at).to eq Time.now
+  end
+
+  it 'should default to an empty expiration time' do
+    expect(@document.expires_at).to be_nil
+  end
+
+  it 'should automatically determine the expiration time' do
+    # TODO: Use Timecop to make this test more precise
+    doc = subject.new '1', 'foo', 'text/plain', 30
+    expect(doc.expires_at).to eq Time.now + 30
+  end
+end

--- a/spec/virginia/document_cache_spec.rb
+++ b/spec/virginia/document_cache_spec.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+require 'spec_helper'
+require 'virginia/document_cache'
+
+describe Virginia::DocumentCache do
+  let(:subject) { Virginia::DocumentCache.new }
+
+  it 'should store the document and return the ID' do
+    expect(subject.store('foo')).to be_a String
+  end
+
+  it 'should allow me to retrieve the document by ID' do
+    doc = 'foobar'
+    id = subject.store doc
+    expect(subject.fetch(id).body).to eq doc
+  end
+
+  it 'should allow me to store and retrieve a document with a specified ID' do
+    subject.store 'foobar', 'text/plain', nil, 'abc123'
+    expect(subject.fetch('abc123').body).to eq 'foobar'
+  end
+
+  it 'should store the document content type' do
+    id = subject.store '{foo: "bar"}', 'application/json'
+    expect(subject.fetch(id).content_type).to eq 'application/json'
+  end
+
+  it 'should allow me to specify a lifetime' do
+    Timecop.freeze
+    id = subject.store 'foobar', 'text/plain', 30
+    doc = subject.fetch id
+    doc.expires_at.should == Time.now + 30
+    Timecop.return
+  end
+
+  it 'should remove (only) expired documents from the cache' do
+    Timecop.freeze
+    id1 = subject.store 'foobar', 'text/plain', 30
+    id2 = subject.store 'bazqux', 'text/plain', 90
+    Timecop.travel Time.now + 60
+    subject.reap_expired!
+
+    expect { subject.fetch(id1) }.to raise_error Virginia::DocumentCache::NotFound
+    expect(subject.fetch(id2).body).to eq 'bazqux'
+    Timecop.return
+  end
+end

--- a/spec/virginia/service_spec.rb
+++ b/spec/virginia/service_spec.rb
@@ -18,7 +18,7 @@ describe Virginia::Service do
   end
 
   it "should instantiate the handler" do
-    rack_logger = mock 'Rack::CommonLogger'
+    rack_logger = double 'Rack::CommonLogger'
     ::Rack::CommonLogger.should_receive(:new).once.with(TestApp, Adhearsion.logger).and_return rack_logger
     ::Reel::Rack::Server.should_receive(:supervise_as).once.with(:reel_rack_server, rack_logger, options)
     Virginia::Service.start

--- a/virginia.gemspec
+++ b/virginia.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<bundler>, ["~> 1.0"]
   s.add_development_dependency %q<rspec>, ["~> 2.5"]
   s.add_development_dependency %q<rake>, [">= 0"]
+  s.add_development_dependency %q<timecop>
   s.add_development_dependency %q<guard-rspec>
  end

--- a/virginia.gemspec
+++ b/virginia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency %q<adhearsion>, ["~> 2.4"]
+  s.add_runtime_dependency %q<adhearsion>, ["~> 2.6"]
   s.add_runtime_dependency %q<activesupport>, [">= 3.0"]
   s.add_runtime_dependency %q<reel>, ["~> 0.5.0"]
   s.add_runtime_dependency %q<reel-rack>


### PR DESCRIPTION
The main goal here was to allow storing the content-type with each cached document, so it could be more easily served back out with Sinatra. In the process I converted the DocumentCache itself to an Actor, created a new Document wrapper, and added specs.