### PR TITLE
Feature/registered documents

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * DocumentCache#fetch no longer accepts a `lifetime` argument. Instead, return an array of arguments suitable for passing to `#store` from the block, or return a complete DocumentCache::Document
   * Switch DocumentCache to an Actor for better performance
   * Load & start DocumentCache's actor by default
+  * Allow registering a document ID with a callback to populate it on demand
 
 # Version 0.4.0
   * Add document cache

--- a/lib/virginia/document_cache.rb
+++ b/lib/virginia/document_cache.rb
@@ -108,7 +108,7 @@ module Virginia
 
     def reap_expired!
       @documents.each_pair do |id, doc|
-        @documents.delete(id) if doc[:expires_at] < Time.now
+        @documents.delete(id) if doc.expires_at && doc.expires_at < Time.now
       end
     end
 

--- a/lib/virginia/document_cache.rb
+++ b/lib/virginia/document_cache.rb
@@ -11,9 +11,7 @@ module Virginia
     DEFAULT_CONTENT_TYPE = 'text/plain'
     DEFAULT_LIFETIME = 10
 
-    execute_block_on_receiver :register
-
-    attr_reader :mutex
+    execute_block_on_receiver :register, :send
 
     class << self
       def method_missing(m, *args, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,9 @@ RSpec.configure do |config|
 
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
+
+  config.after :each do
+    Timecop.return
+  end
 end
 

--- a/spec/virginia/document_cache/document_spec.rb
+++ b/spec/virginia/document_cache/document_spec.rb
@@ -9,10 +9,6 @@ describe Virginia::DocumentCache::Document do
     @document = subject.new 'fake_id', 'fake_content'
   end
 
-  after :each do
-    Timecop.return
-  end
-
   it 'should accurately represent my content' do
     expect(@document.body).to eq 'fake_content'
   end

--- a/spec/virginia/document_cache_spec.rb
+++ b/spec/virginia/document_cache_spec.rb
@@ -29,7 +29,19 @@ describe Virginia::DocumentCache do
     Timecop.freeze
     id = subject.store 'foobar', 'text/plain', 30
     doc = subject.fetch id
-    doc.expires_at.should == Time.now + 30
+    expect(doc.expires_at).to eq Time.now + 30
+    Timecop.return
+  end
+
+  it 'should allow documents that do not expire' do
+    Timecop.freeze
+    id = subject.store 'foobar', 'text/plain', nil
+    doc = subject.fetch id
+    expect(doc.expires_at).to be nil
+    Timecop.travel Time.now + (20 * 365 * 24 * 60 * 60) # 20 years
+    subject.reap_expired!
+    doc = subject.fetch id
+    expect(doc.body).to eq 'foobar'
     Timecop.return
   end
 

--- a/spec/virginia/document_cache_spec.rb
+++ b/spec/virginia/document_cache_spec.rb
@@ -30,7 +30,6 @@ describe Virginia::DocumentCache do
     id = subject.store 'foobar', 'text/plain', 30
     doc = subject.fetch id
     expect(doc.expires_at).to eq Time.now + 30
-    Timecop.return
   end
 
   it 'should allow documents that do not expire' do
@@ -42,7 +41,6 @@ describe Virginia::DocumentCache do
     subject.reap_expired!
     doc = subject.fetch id
     expect(doc.body).to eq 'foobar'
-    Timecop.return
   end
 
   it 'should remove (only) expired documents from the cache' do
@@ -54,7 +52,6 @@ describe Virginia::DocumentCache do
 
     expect { subject.fetch(id1) }.to raise_error Virginia::DocumentCache::NotFound
     expect(subject.fetch(id2).body).to eq 'bazqux'
-    Timecop.return
   end
 
   context 'auto-creation on #fetch' do
@@ -68,12 +65,11 @@ describe Virginia::DocumentCache do
       expect { subject.fetch(doc_id) }.to raise_error Virginia::DocumentCache::NotFound
     end
 
-    after :each do 
+    after :each do
       doc = subject.fetch doc_id
       expect(doc.body).to eq body
       expect(doc.content_type).to eq ctype
       expect(doc.expires_at).to eq Time.now + lifetime
-      Timecop.return
     end
 
     it 'should allow me to supply a block to #store and create a document if one is not already cached' do
@@ -100,14 +96,7 @@ describe Virginia::DocumentCache do
       Timecop.freeze
     end
 
-    after :each do
-      Timecop.return
-    end
-
     context 'auto-creating documents' do
-      before :each do
-      end
-
       after :each do
         doc = subject.fetch doc_id
         expect(doc.body).to eq body
@@ -137,12 +126,11 @@ describe Virginia::DocumentCache do
       doc = subject.fetch(doc_id)
 
       # Move past expiration and clean up the cached document
-      Timecop.travel Time.now + (lifetime + 1) 
+      Timecop.travel Time.now + (lifetime + 1)
       subject.reap_expired!
 
       subject.unregister(doc_id)
       expect { subject.fetch(doc_id) }.to raise_error Virginia::DocumentCache::NotFound
-      Timecop.return
     end
   end
 end


### PR DESCRIPTION
Allow registering a creator for a given document ID

Each time the specific document ID is requested, if it is not present in the cache, the callback will be invoked to populate it